### PR TITLE
Merge branch 'jgm:main' into dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ VIMDIR?=~/.vim
 
 all: doc/syntax.html
 
+# luarocks install --lua-version=5.4 djot
+
 doc/syntax.html: doc/syntax.md
-	pandoc --lua-filter doc/code-examples.lua $< -t html -o $@ -s --css doc/syntax.css --self-contained --wrap=preserve --toc --section-divs -Vpagetitle="Djot syntax reference"
+	pandoc --lua-filter doc/code-examples.lua $< -t html -o $@ -s --css doc/syntax.css --embed-resources --wrap=preserve --toc --section-divs -Vpagetitle="Djot syntax reference"
 

--- a/README.md
+++ b/README.md
@@ -324,10 +324,24 @@ There are currently six djot implementations:
 - [godjot (Go)](https://github.com/sivukhin/godjot)
 - [djoths (Haskell)](https://github.com/jgm/djoths)
 
+[Here](https://github.com/dcampbell24/djot-implementations) are some benchmarks of these implementations.
+
 djot.lua was the original reference implementation, but
 current development is focused on djot.js, and it is possible
 that djot.lua will not be kept up to date with the latest syntax
 changes.
+
+## Tooling
+
+- [Vim tooling](./editors/vim/) (located in this repo)
+- Visual Studio Code tooling
+  - [djot-vscode](https://github.com/ryanabx/djot-vscode)
+  - [Djot-Marker](https://github.com/wisim3000/Djot-Marker)
+- [Treesitter grammar](https://github.com/treeman/tree-sitter-djot)
+- [Emacs major mode](./editors/emacs/)
+  (located in this repo, requires the treesitter grammar)
+- [Djockey](https://steveasleep.com/djockey/), a static site generator
+  for technical writing and project documentation.
 
 ## File extension
 

--- a/doc/syntax.html
+++ b/doc/syntax.html
@@ -11,8 +11,10 @@ span.smallcaps{font-variant: small-caps;}
 div.columns{display: flex; gap: min(4vw, 1.5em);}
 div.column{flex: auto; overflow-x: auto;}
 div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-ul.task-list{list-style: none;}
+
+ul.task-list[class]{list-style: none;}
 ul.task-list li input[type="checkbox"] {
+font-size: inherit;
 width: 0.8em;
 margin: 0 0.8em 0.2em -1.6em;
 vertical-align: middle;
@@ -233,9 +235,6 @@ background-color: #ddd;
 font-size: 78%;
 }
 </style>
-  <!--[if lt IE 9]>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
-  <![endif]-->
 </head>
 <body>
 <nav id="TOC" role="doc-toc">
@@ -762,7 +761,7 @@ Pythagoras proved
 <h3>Line break</h3>
 <p>Line breaks in inline content are treated as “soft” breaks; they may be
 rendered as spaces, or (in contexts where newlines are treated
-semantically like spaces, such as HTML) as as newlines.</p>
+semantically like spaces, such as HTML) as newlines.</p>
 <p>To get a hard line break (of the sort represented by HTML’s <code>&lt;br&gt;</code>), use
 backslash + newline:</p>
 <div class="example">
@@ -815,7 +814,7 @@ emojis. But this is not built into djot.)</p>
 <pre><code>My reaction is :+1: :smiley:.</code></pre>
 </div>
 <div class="html">
-<pre><code>&lt;p&gt;My reaction is 👍 😃.&lt;/p&gt;
+<pre><code>&lt;p&gt;My reaction is :+1: :smiley:.&lt;/p&gt;
 </code></pre>
 </div>
 </div>
@@ -1080,89 +1079,89 @@ list item.&lt;/p&gt;
 <p>The following basic types of list markers are available:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>Marker</th>
 <th>List type</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><code>-</code></td>
 <td>bullet</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>+</code></td>
 <td>bullet</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>*</code></td>
 <td>bullet</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>1.</code></td>
 <td>ordered, decimal-enumerated, followed by period</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>1)</code></td>
 <td>ordered, decimal-enumerated, followed by parenthesis</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>(1)</code></td>
 <td>ordered, decimal-enumerated, enclosed in parentheses</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>a.</code></td>
 <td>ordered, lower-alpha-enumerated, followed by period</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>a)</code></td>
 <td>ordered, lower-alpha-enumerated, followed by parenthesis</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>(a)</code></td>
 <td>ordered, lower-alpha-enumerated, enclosed in parentheses</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>A.</code></td>
 <td>ordered, upper-alpha-enumerated, followed by period</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>A)</code></td>
 <td>ordered, upper-alpha-enumerated, followed by parenthesis</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>(A)</code></td>
 <td>ordered, upper-alpha-enumerated, enclosed in parentheses</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>i.</code></td>
 <td>ordered, lower-roman-enumerated, followed by period</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>i)</code></td>
 <td>ordered, lower-roman-enumerated, followed by parenthesis</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>(i)</code></td>
 <td>ordered, lower-roman-enumerated, enclosed in parentheses</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>I.</code></td>
 <td>ordered, upper-roman-enumerated, followed by period</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>I)</code></td>
 <td>ordered, upper-roman-enumerated, followed by parenthesis</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>(I)</code></td>
 <td>ordered, upper-roman-enumerated, enclosed in parentheses</td>
 </tr>
-<tr class="odd">
+<tr>
 <td><code>:</code></td>
 <td>definition</td>
 </tr>
-<tr class="even">
+<tr>
 <td><code>- [ ]</code></td>
 <td>task</td>
 </tr>
@@ -1716,8 +1715,9 @@ be indented, at least in the first line.&lt;a href=&quot;#fnref1&quot; role=&quo
 <h3>Block attributes</h3>
 <p>To attach attributes to a block-level element, put the attributes on the
 line immediately before the block. Block attributes have the same syntax
-as inline attributes, but they must fit on one line. Repeated attribute
-specifiers can be used, and the attributes will accumulate.</p>
+as inline attributes, but if they don’t fit on one line, subsequent lines
+must be indented. Repeated attribute specifiers can be used, and
+the attributes will accumulate.</p>
 <div class="example">
 <div class="djot">
 <pre><code>{#water}

--- a/editors/emacs/djot.el
+++ b/editors/emacs/djot.el
@@ -1,0 +1,307 @@
+;;; djot.el              -*- lexical-binding: t -*-
+
+;; Copyright (C) 2024 John MacFarlane
+
+;; Author: John MacFarlane <jgm@berkeley.edu>
+;; Keywords: lisp djot
+;; Version 0.0.1
+
+;;; Commentary:
+
+;; Major mode for djot, using tree-sitter grammar
+;; https://github.com/treeman/tree-sitter-djot
+
+;; This is rudimentary and should be improved in the future.
+
+;;; Code:
+
+;; note: M-x list-faces-display will get you a list of font-lock-X
+
+(defgroup djot-faces nil
+  "Faces used in Djot mode"
+  :group 'djot
+  :group 'faces)
+
+(defface djot-delimiter-face
+  '((t :inherit font-lock-delimiter-face))
+  "Face for delimiters."
+  :group 'djot-faces)
+
+(defface djot-emphasis-face
+  '((t :italic t))
+  "Face for emphasized text."
+  :group 'djot-faces)
+
+(defface djot-strong-face
+  '((t :bold t))
+  "Face for strongly emphasized text."
+  :group 'djot-faces)
+
+(defface djot-heading-face
+  '((t :weight bold))
+  "Base face for headings."
+  :group 'djot-faces)
+
+(defface djot-heading1-face
+  '((t :inherit djot-heading-face))
+  "Face for level-1 headings."
+  :group 'djot-faces)
+
+(defface djot-heading2-face
+  '((t :inherit djot-heading-face))
+  "Face for level-2 headings."
+  :group 'djot-faces)
+
+(defface djot-heading3-face
+  '((t :inherit djot-heading-face))
+  "Face for level-3 headings."
+  :group 'djot-faces)
+
+(defface djot-heading4-face
+  '((t :inherit djot-heading-face))
+  "Face for level-4 headings."
+  :group 'djot-faces)
+
+(defface djot-heading5-face
+  '((t :inherit djot-heading-face))
+  "Face for level-5 headings."
+  :group 'djot-faces)
+
+(defface djot-heading6-face
+  '((t :inherit djot-heading-face))
+  "Face for level-6 headings."
+  :group 'djot-faces)
+
+(defface djot-list-marker-face
+  '((t :inherit font-lock-builtin-face))
+  "Face for list markers."
+  :group 'djot-faces)
+
+(defface djot-verbatim-face
+  '((t :inherit fixed-pitch :inherit highlight))
+  "Face for verbatim."
+  :group 'djot-faces)
+
+(defface djot-attribute-face
+  '((t :inherit font-lock-comment-face))
+  "Face for attribute."
+  :group 'djot-faces)
+
+(defface djot-list-face
+  '((t :inherit font-lock-builtin-face))
+  "Face for list item markers."
+  :group 'djot-faces)
+
+(defface djot-block-quote-face
+  '((t :inherit font-lock-builtin-face))
+  "Face for block quote sections."
+  :group 'djot-faces)
+
+(defface djot-code-block-face
+  '((t :inherit djot-verbatim-face))
+  "Face for code block."
+  :group 'djot-faces)
+
+(defface djot-code-block-language-face
+  '((t :inherit font-lock-comment-face))
+  "Face for code block language."
+  :group 'djot-faces)
+
+(defface djot-span-face
+  '((t :inherit font-lock-keyword-face))
+  "Face for span."
+  :group 'djot-faces)
+
+(defface djot-link-text-face
+  '((t :inherit link))
+  "Face for link text."
+  :group 'djot-faces)
+
+(defface djot-link-destination-face
+  '((t :inherit font-lock-type-face))
+  "Face for link destination."
+  :group 'djot-faces)
+
+(defface djot-reference-face
+  '((t :inherit font-lock-type-face))
+  "Face for link references."
+  :group 'djot-faces)
+
+(defface djot-url-face
+  '((t :inherit font-lock-keyword-face))
+  "Face for URLs."
+  :group 'djot-faces)
+
+(defface djot-math-face
+  '((t :inherit font-lock-string-face))
+  "Face for math."
+  :group 'djot-faces)
+
+(defvar djot-ts-font-lock-rules
+  '(
+    :language djot
+    :override prepend
+    :feature verbatim
+    ((verbatim
+      (verbatim_marker_begin) @djot-delimiter-face
+      (content) @djot-verbatim-face
+      (verbatim_marker_end) @djot-delimiter-face))
+
+    :language djot
+    :override prepend
+    :feature emphasis
+    ((emphasis
+      (emphasis_begin _) @djot-delimiter-face
+      (content) @djot-emphasis-face
+      (emphasis_end _) @djot-delimiter-face)
+     (strong
+      (strong_begin _) @djot-delimiter-face
+      (content) @djot-strong-face
+      (strong_end _) @djot-delimiter-face))
+
+    :language djot
+    :override prepend
+    :feature math
+    ((math
+      (math_marker) @djot-delimiter-face
+      (math_marker_begin) @djot-delimiter-face
+      (content) @djot-math-face
+      (math_marker_end) @djot-delimiter-face))
+
+    :language djot
+    :override prepend
+    :feature span
+    ((span) @djot-span-face)
+
+    :language djot
+    :override prepend
+    :feature div
+    ((div_marker_begin) @djot-delimiter-face
+     (div_marker_end) @djot-delimiter-face)
+
+    :language djot
+    :override prepend
+    :feature link
+    ((inline_link
+      (link_text) @djot-link-text-face
+      (inline_link_destination) @djot-link-destination-face)
+     (inline_image
+      (image_description) @djot-link-text-face
+      (inline_link_destination) @djot-link-destination-face)
+     (collapsed_reference_link
+      (link_text) @djot-link-text-face
+      "[]" @djot-link-destination-face)
+     (full_reference_link
+      (link_text) @djot-link-text-face
+      (link_label) @djot-link-destination-face)
+     (autolink) @djot-link-text-face
+     (link_reference_definition
+      (link_label) @djot-reference-face
+      (link_destination) @djot-link-destination-face))
+
+    :language djot
+    :override t
+    :feature block_quote
+    ((block_quote
+      (content) @djot-block-quote-face)
+     (block_quote_marker) @djot-delimiter-face)
+
+    :language djot
+    :override t
+    :feature attribute
+    ((block_attribute _ @djot-attribute-face)
+     (inline_attribute _ @djot-attribute-face))
+
+    :language djot
+    :override t
+    :feature list
+    ([ (list_marker_definition)
+       (list_marker_dash)
+       (list_marker_star)
+       (list_marker_task _)
+       (list_marker_decimal_period)
+       (list_marker_lower_alpha_period)
+       (list_marker_lower_roman_period)
+       (list_marker_upper_alpha_period)
+       (list_marker_upper_roman_period)
+       (list_marker_decimal_paren)
+       (list_marker_lower_alpha_paren)
+       (list_marker_lower_roman_paren)
+       (list_marker_upper_alpha_paren)
+       (list_marker_upper_roman_paren)
+       (list_marker_decimal_parens)
+       (list_marker_lower_alpha_parens)
+       (list_marker_lower_roman_parens)
+       (list_marker_upper_alpha_parens)
+       (list_marker_upper_roman_parens)
+       ] @djot-list-marker-face)
+
+    :language djot
+    :override t
+    :feature code_block
+    ((code_block
+      (code_block_marker_begin) @djot-delimiter-face
+      (code) @djot-code-block-face
+      (code_block_marker_end) @djot-delimiter-face)
+     (code_block
+      (language) @djot-code-block-language-face)
+     )
+
+    :language djot
+    :override t
+    :feature heading
+    ((heading1
+      (marker) @djot-delimiter-face
+      (content) @djot-heading1-face)
+     (heading2
+      (marker) @djot-delimiter-face
+      (content) @djot-heading2-face)
+     (heading3
+      (marker) @djot-delimiter-face
+      (content) @djot-heading3-face)
+     (heading4
+      (marker) @djot-delimiter-face
+      (content) @djot-heading4-face)
+     (heading5
+      (marker) @djot-delimiter-face
+      (content) @djot-heading5-face)
+     (heading6
+      (marker) @djot-delimiter-face
+      (content) @djot-heading6-face))
+    ))
+
+(defun djot-ts-imenu-node-p (node)
+  (string-match-p "^heading" (treesit-node-type node)))
+
+(defun djot-ts-imenu-name-function (node)
+  (replace-regexp-in-string "\n\\'" "" (treesit-node-text node)))
+
+(defun djot-ts-setup ()
+  "Setup treesit for djot-ts-mode."
+
+  (setq-local treesit-font-lock-settings
+              (apply #'treesit-font-lock-rules
+                     djot-ts-font-lock-rules))
+
+  (setq-local treesit-font-lock-feature-list
+              '((verbatim attribute heading block_quote code_block list)
+                (emphasis link math span)))
+
+  (setq-local treesit-simple-imenu-settings
+              `((nil ;; "Heading" but there's no point since this is all we do
+                 djot-ts-imenu-node-p
+                 nil
+                 djot-ts-imenu-name-function)))
+
+  (treesit-major-mode-setup))
+
+(define-derived-mode djot-ts-mode text-mode "Djot"
+  "Major mode for editing Djot with tree-sitter."
+
+  (setq-local font-lock-defaults nil)
+  (when (treesit-ready-p 'djot)
+    (treesit-parser-create 'djot)
+    (djot-ts-setup)))
+
+(provide 'djot-ts-mode)
+;;; djot.el ends here

--- a/editors/vim/syntax/djot.vim
+++ b/editors/vim/syntax/djot.vim
@@ -17,11 +17,11 @@ syn region comment matchgroup=delimiter start='%' end='%' contained
 syn region string start='"' end='"' skip='\\"'
 syn region attributes matchgroup=delimiter start="{[^\[\]_*'\"=\\+-]\@=" end="}" contains=string,comment
 
-syn region emphasis matchgroup=delimiter start='_[^\s}]\@=\|{_' end='_}\|[^\s{]\@=_\|^\s*$' contains=@inline
-syn region strong matchgroup=delimiter start='\*[^\s}]\@=\|{\*' end='[^\s{]\@=\*\|\*}\|^\s*$' contains=@inline
+syn region emphasis matchgroup=delimiter start='_[^[:blank:]}]\@=\|{_' end='_}\|[^[:blank:]{]\@=_\|^\s*$' contains=@inline
+syn region strong matchgroup=delimiter start='\*[^[:blank:]}]\@=\|{\*' end='[^[:blank:]{]\@=\*\|\*}\|^\s*$' contains=@inline
 
-syn region superscript matchgroup=delimiter start='\^[^\s}]\@=\|{\^' end='\^}\|[^\s{]\@=\^\|^\s*$' contains=@inline
-syn region subscript matchgroup=delimiter start='\~[^\s}]\@=\|{\~' end='\~}\|[^\s{]\@=\~\|^\s*$' contains=@inline
+syn region superscript matchgroup=delimiter start='\^[^[:blank:]}]\@=\|{\^' end='\^}\|[^[:blank:]{]\@=\^\|^\s*$' contains=@inline
+syn region subscript matchgroup=delimiter start='\~[^[:blank:]}]\@=\|{\~' end='\~}\|[^[:blank:]{]\@=\~\|^\s*$' contains=@inline
 
 syn region highlight matchgroup=delimiter start='{=' end='=}\|^\s*$' contains=@inline
 syn match rawattribute "`\@<={=[A-Za-z0-9]*}"


### PR DESCRIPTION
This pull request includes several changes to improve documentation, HTML formatting, and editor support for Djot. The most significant changes include adding benchmarks to the README, updating HTML syntax, and introducing a new Emacs major mode for Djot.

### Documentation Updates:
* Added benchmarks for Djot implementations and a new section on tooling in the `README.md` file.

### HTML Formatting:
* Updated the `doc/syntax.html` file to improve task list styling, remove outdated IE compatibility scripts, and correct minor typographical errors. [[1]](diffhunk://#diff-f9c6ea34b436ccd87010cf7b158535e24723bd7014496c4235cc793192497233L14-R17) [[2]](diffhunk://#diff-f9c6ea34b436ccd87010cf7b158535e24723bd7014496c4235cc793192497233L236-L238) [[3]](diffhunk://#diff-f9c6ea34b436ccd87010cf7b158535e24723bd7014496c4235cc793192497233L765-R764) [[4]](diffhunk://#diff-f9c6ea34b436ccd87010cf7b158535e24723bd7014496c4235cc793192497233L818-R817) [[5]](diffhunk://#diff-f9c6ea34b436ccd87010cf7b158535e24723bd7014496c4235cc793192497233L1083-R1164) [[6]](diffhunk://#diff-f9c6ea34b436ccd87010cf7b158535e24723bd7014496c4235cc793192497233L1719-R1720)

### Editor Support:
* Added a new Emacs major mode for Djot with tree-sitter grammar in `editors/emacs/djot.el`.
* Updated Vim syntax highlighting in `editors/vim/syntax/djot.vim` to handle whitespace more accurately.

### Build System:
* Modified the `Makefile` to use `--embed-resources` instead of `--self-contained` for generating HTML documentation.<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
